### PR TITLE
dplyr 1.0.8: avoid using matrices in filter()

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -282,11 +282,8 @@ exclude_cases <- function(excl_data_sets){
   # Exclude cases
   # Remove empty data -- this can happen
   # if you have removed too many participants
-  excl_data_sets <-
-    excl_data_sets %>%
-    dplyr::mutate(excl = excl_data_sets$used_data %>%
-                    lapply(plyr::empty) %>%
-                    data.frame() %>% t())
+  excl_data_sets <- excl_data_sets %>%
+    dplyr::mutate(excl = purrr::map_lgl(excl_data_sets$used_data, plyr::empty))
 
   # Return warning if you have excluded any of the data sets
   if (any(excl_data_sets$excl == TRUE)) {


### PR DESCRIPTION
We're about to release dplyr 1.0.8 and we've identified this problem as part of our rev dep checks. This is related to the change in `filter()` to no longer treat matrices. 

We may have a workaround before we release dplyr, but still I would encourage you to release `multiyear` with this fix. 